### PR TITLE
Typo

### DIFF
--- a/quickstart/web_server/nginx_service.yaml
+++ b/quickstart/web_server/nginx_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: nginx-service
 spec:
-  type: nodePort
+  type: NodePort
   selector: 
     app: nginx
   ports:


### PR DESCRIPTION
It seems a typo here.

Otherwise, when create this service, kubectl will error as `The Service "ubuntu-service" is invalid: spec.type: Unsupported value: "nodePort": supported values: ClusterIP, ExternalName, LoadBalancer, NodePort`